### PR TITLE
feat: 일정 생성 기능 구현 (Lv1)

### DIFF
--- a/src/main/java/org/example/scheduleapi/ScheduleApiApplication.java
+++ b/src/main/java/org/example/scheduleapi/ScheduleApiApplication.java
@@ -2,7 +2,9 @@ package org.example.scheduleapi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class ScheduleApiApplication {
 

--- a/src/main/java/org/example/scheduleapi/controller/ScheduleController.java
+++ b/src/main/java/org/example/scheduleapi/controller/ScheduleController.java
@@ -1,0 +1,25 @@
+package org.example.scheduleapi.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.scheduleapi.dto.ScheduleRequestDto;
+import org.example.scheduleapi.dto.ScheduleResponseDto;
+import org.example.scheduleapi.service.SchedulesService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/schedules")
+@RequiredArgsConstructor
+public class ScheduleController {
+
+    private final SchedulesService schedulesService;
+
+    @PostMapping
+    public ResponseEntity<ScheduleResponseDto> createSchedule(@RequestBody ScheduleRequestDto requestDto) {
+        return new ResponseEntity<>(schedulesService.saveSchedule(requestDto), HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/org/example/scheduleapi/dto/ScheduleRequestDto.java
+++ b/src/main/java/org/example/scheduleapi/dto/ScheduleRequestDto.java
@@ -1,0 +1,24 @@
+package org.example.scheduleapi.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.example.scheduleapi.entity.Schedule;
+
+@Getter
+public class ScheduleRequestDto {
+
+    private String title;
+    private String contents;
+    private String author;
+    private String password;
+
+    public Schedule toEntity() {
+        return Schedule.builder()
+                .title(title)
+                .contents(contents)
+                .author(author)
+                .password(password)
+                .build();
+    }
+
+}

--- a/src/main/java/org/example/scheduleapi/dto/ScheduleResponseDto.java
+++ b/src/main/java/org/example/scheduleapi/dto/ScheduleResponseDto.java
@@ -1,0 +1,28 @@
+package org.example.scheduleapi.dto;
+
+import lombok.Getter;
+import org.example.scheduleapi.entity.Schedule;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+
+@Getter
+public class ScheduleResponseDto {
+
+    private Long id;
+    private String title;
+    private String contents;
+    private String author;
+    private LocalDateTime created_at;
+    private LocalDateTime updated_at;
+
+    public ScheduleResponseDto(Schedule schedule) {
+        this.id = schedule.getId();
+        this.title = schedule.getTitle();
+        this.contents = schedule.getContents();
+        this.author = schedule.getAuthor();
+        this.created_at = schedule.getCreatedAt();
+        this.updated_at = schedule.getUpdatedAt();
+    }
+
+}

--- a/src/main/java/org/example/scheduleapi/entity/BaseEntity.java
+++ b/src/main/java/org/example/scheduleapi/entity/BaseEntity.java
@@ -1,0 +1,24 @@
+package org.example.scheduleapi.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/example/scheduleapi/entity/Schedule.java
+++ b/src/main/java/org/example/scheduleapi/entity/Schedule.java
@@ -1,18 +1,15 @@
 package org.example.scheduleapi.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.Date;
 
 @Entity
 @Getter
 @NoArgsConstructor
-public class Schedule {
+@Table(name = "schedules")
+public class Schedule extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
@@ -21,7 +18,13 @@ public class Schedule {
     private String contents;
     private String author;
     private String password;
-    private Date created_at;
-    private Date updated_at;
+
+    @Builder
+    public Schedule(String title, String contents, String author, String password) {
+        this.title = title;
+        this.contents = contents;
+        this.author = author;
+        this.password = password;
+    }
 
 }

--- a/src/main/java/org/example/scheduleapi/entity/Schedule.java
+++ b/src/main/java/org/example/scheduleapi/entity/Schedule.java
@@ -1,0 +1,27 @@
+package org.example.scheduleapi.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Schedule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+    private String title;
+    private String contents;
+    private String author;
+    private String password;
+    private Date created_at;
+    private Date updated_at;
+
+}

--- a/src/main/java/org/example/scheduleapi/repository/ScheduleRepository.java
+++ b/src/main/java/org/example/scheduleapi/repository/ScheduleRepository.java
@@ -1,0 +1,7 @@
+package org.example.scheduleapi.repository;
+
+import org.example.scheduleapi.entity.Schedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+}

--- a/src/main/java/org/example/scheduleapi/service/ScheduleServiceImpl.java
+++ b/src/main/java/org/example/scheduleapi/service/ScheduleServiceImpl.java
@@ -1,0 +1,23 @@
+package org.example.scheduleapi.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.scheduleapi.dto.ScheduleRequestDto;
+import org.example.scheduleapi.dto.ScheduleResponseDto;
+import org.example.scheduleapi.entity.Schedule;
+import org.example.scheduleapi.repository.ScheduleRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduleServiceImpl implements SchedulesService {
+
+    private final ScheduleRepository scheduleRepository;
+
+    @Override
+    @Transactional
+    public ScheduleResponseDto saveSchedule(ScheduleRequestDto requestDto) {
+        Schedule savedSchedule = scheduleRepository.save(requestDto.toEntity());
+        return new ScheduleResponseDto(savedSchedule);
+    }
+}

--- a/src/main/java/org/example/scheduleapi/service/SchedulesService.java
+++ b/src/main/java/org/example/scheduleapi/service/SchedulesService.java
@@ -1,0 +1,8 @@
+package org.example.scheduleapi.service;
+
+import org.example.scheduleapi.dto.ScheduleRequestDto;
+import org.example.scheduleapi.dto.ScheduleResponseDto;
+
+public interface SchedulesService {
+     ScheduleResponseDto saveSchedule(ScheduleRequestDto requestDto);
+}


### PR DESCRIPTION

## 구현 내용  
- 일정 생성 기능 구현 (Lv1)  
- 일정 제목, 내용, 작성자명, 비밀번호, 작성/수정일 저장  
- JPA Auditing 적용으로 작성/수정일 자동 관리  
- API 응답 시 비밀번호 제외 처리  

## 변경 사항  
- ScheduleRequestDto, ScheduleResponseDto 클래스 추가  
- Schedule 엔티티 및 Repository 추가  
- ScheduleService, ScheduleController 일정 생성 메서드 구현  
- JPA Auditing 설정 추가  

